### PR TITLE
Release gcs-resumable-upload v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+[npm history][1]
+
+[1]: https://www.npmjs.com/package/gcs-resumable-upload?activeTab=versions
+
+## v0.12.0
+
+### Implemenation Changes
+BREAKING CHANGE:
+- chore: drop support for node.js 4 (#75)
+
+### Dependencies
+- chore(deps): update dependency gts to ^0.8.0 (#71)
+- fix(deps): update dependency configstore to v4 (#72)
+- chore(deps): update dependency typescript to v3 (#74)
+
+### Internal / Testing Changes
+- chore: make it OSPO compliant (#73)
+- fix: quarantine axios types (#70)
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcs-resumable-upload",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Upload a file to Google Cloud Storage with built-in resumable behavior",
   "repository": "stephenplusplus/gcs-resumable-upload",
   "main": "build/src/index.js",


### PR DESCRIPTION
Current version breaks downstream packages, namely `nodejs-storage` (because of noSyntheticDefaultImports).